### PR TITLE
fix: switch golangci-lint to official action with hash pinning

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,21 +31,10 @@ jobs:
         with:
           go-version: '1.26.2'
 
-      - name: Setup GoLangCI-Lint
-        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s 
-
-      - name: Show GoLangCI-Lint version
-        run: ./bin/golangci-lint --version | head -n1
-
       - name: Run GoLangCI-Lint
-        run: >
-          github-comment exec --token ${{ secrets.GITHUB_TOKEN }} --
-          ../bin/golangci-lint run
-        working-directory: ./src
-
-      - name: Hide old comment
-        run: github-comment hide --token ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ github.event_name == 'pull_request' || ( github.event_name == 'push' && github.ref_name != 'main' ) }}
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        with:
+          working-directory: ./src
 
       - name: Build 
         run: go build


### PR DESCRIPTION
## Summary

- `curl` によるスクリプトインストールをやめ、公式の `golangci/golangci-lint-action` に切り替え
- コミット SHA でバージョンを固定（Hash Pinning）: `1e7e51e771db61008b38414a730f564565cf7c20` (v9.2.0)
- `github-comment` による PR コメント投稿も削除（Action が GitHub Annotations として直接表示）

## Background

PR #364 の CI が以下のエラーで失敗していた:

```
golangci/golangci-lint err hash_sha256_verify checksum for 'golangci-lint-2.12.2-linux-amd64.tar.gz' did not verify
```

`master` ブランチのインストールスクリプトを使ってバージョン未固定でインストールしていたため、チェックサム不一致が発生。

## Test plan

- [ ] CI (`build_and_test`) が通ることを確認
- [ ] PR の "Files changed" で golangci-lint の Annotations が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)