### PR TITLE
fix: remove exclude-use-default from golangci-lint config

### DIFF
--- a/src/.golangci.yaml
+++ b/src/.golangci.yaml
@@ -15,7 +15,3 @@ linters:
   settings:
     govet:
       enable-all: true
-
-issues:
-  exclude-use-default: false
-


### PR DESCRIPTION
## Summary

- golangci-lint v2.x で `issues.exclude-use-default` オプションが削除されたため、CI が失敗していた
- `.golangci.yaml` から当該オプションを削除して修正

## Background

PR #364 の CI で以下のエラーが発生していた:
```
jsonschema: "issues" does not validate with "/properties/issues/additionalProperties":
additional properties 'exclude-use-default' not allowed
```

golangci-lint v2.12.2 (latest) が `issues.exclude-use-default` を非サポートとなったことが原因。

## Test plan

- [ ] CI の `build_and_test` が通過することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)